### PR TITLE
Add option to configure unique identifier in Github Pull Request status (default Drone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ client=""
 secret=""
 orgs=[]
 open=false
+status_context=Drone
 
 [github_enterprise]
 client=""

--- a/packaging/root/etc/drone/drone.toml
+++ b/packaging/root/etc/drone/drone.toml
@@ -33,6 +33,7 @@ datasource="/var/lib/drone/drone.sqlite"
 # secret=""
 # orgs=[]
 # open=false
+# status_context=Drone
 
 # [github_enterprise]
 # client=""

--- a/plugin/notify/github/github.go
+++ b/plugin/notify/github/github.go
@@ -1,3 +1,4 @@
+// See https://developer.github.com/v3/repos/statuses/
 package github
 
 import (
@@ -5,6 +6,7 @@ import (
 	"net/url"
 
 	"code.google.com/p/goauth2/oauth"
+	"github.com/drone/config"
 	"github.com/drone/drone/shared/model"
 	"github.com/google/go-github/github"
 )
@@ -31,6 +33,10 @@ const (
 
 const (
 	BaseURL = "https://api.github.com/"
+)
+
+var (
+	GithubStatusContext = config.String("github-status-context", "Drone")
 )
 
 type GitHub string
@@ -83,7 +89,7 @@ func send(rawurl, host, owner, repo, status, desc, target, ref, token string) er
 	}
 
 	data := github.RepoStatus{
-		Context:     github.String("Drone"),
+		Context:     github.String(*GithubStatusContext),
 		State:       github.String(status),
 		Description: github.String(desc),
 		TargetURL:   github.String(target),


### PR DESCRIPTION
This makes possible connecting several Drone servers to GitHub repo and make all the statuses visible in GitHub Pull Request status.
When identifier is hardcoded, even if you connect several services - only 1 unique will show up:

![](http://i.imgur.com/iw1caox.png)
